### PR TITLE
Dynamic Gossip Auto-Selection

### DIFF
--- a/LazyPig.lua
+++ b/LazyPig.lua
@@ -218,6 +218,9 @@ function LazyPig_Command(msg)
 		elseif subcmd == "remove" and pattern and pattern ~= "" then
 			LPCONFIG.GOSSIP_AUTO_SELECT[pattern] = nil
 			DEFAULT_CHAT_FRAME:AddMessage("|cffff0000LazyPig: Removed gossip auto-select for '"..pattern.."'|r")
+		elseif subcmd == "clear" then
+			LPCONFIG.GOSSIP_AUTO_SELECT = {}
+			DEFAULT_CHAT_FRAME:AddMessage("|cffff0000LazyPig: Cleared all gossip auto-select patterns|r")
 		elseif subcmd == "list" then
 			DEFAULT_CHAT_FRAME:AddMessage("|cff00eeeeLazyPig: Gossip Auto-Select Patterns:|r")
 			local count = 0
@@ -234,6 +237,7 @@ function LazyPig_Command(msg)
 			DEFAULT_CHAT_FRAME:AddMessage("|cff00eeeeLazyPig Gossip Commands:|r")
 			DEFAULT_CHAT_FRAME:AddMessage("  /lp gossip add <text> - Add gossip text pattern")
 			DEFAULT_CHAT_FRAME:AddMessage("  /lp gossip remove <text> - Remove gossip text pattern")
+			DEFAULT_CHAT_FRAME:AddMessage("  /lp gossip clear - Clear all patterns")
 			DEFAULT_CHAT_FRAME:AddMessage("  /lp gossip list - List all patterns")
 		end
 	else


### PR DESCRIPTION
A pattern-matching system for automatic gossip selection when NPCs offer multiple dialogue options.

### Problem

Repetitive turn-ins become tedious when you must manually select the same option each time:
- **Spirit of Zanza** - Choosing specific buffs from Zandalar Tribe NPCs
- **Corrupted Dream Shards** - Selecting turn-in options in Hyjal
- **Raid consumables** - NPCs offering multiple buff or item exchanges
- **Reputation turn-ins** - Token exchange vendors with multiple choices

### Solution
Define text patterns once, then hold Alt to auto-select matching gossip options.

### Usage

#### Configure your patterns:

/lp gossip add "Spirit of Zanza"
/lp gossip add "Corrupted Dream Shard"
/lp gossip add "Sand in Bulk"

Hold `Alt` when interacting with these NPCs to instantly select the matching option.

**Additional commands:**
- `/lp gossip list` - View configured patterns
- `/lp gossip remove "text"` - Remove a pattern
- `/lp gossip clear` - Clear all patterns

### Implementation

case-insensitive substring matching across available quests, active quests, and gossip options. Patterns persist between sessions and integrate with existing gossip auto-processing (bypass with Shift).